### PR TITLE
Set the version of Scipy to 1.2.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ pytest = "*"
 [packages]
 attrs = "*"
 pandas = "*"
-scipy = "*"
+scipy = "==1.2.0"
 sklearn = "*"
 statsmodels = "*"
 bootstrapped = "*"


### PR DESCRIPTION
Other dependencies call factorial in a deprecated way.