### PR TITLE
Enable loading data from pandas DataFrame

### DIFF
--- a/tea/api.py
+++ b/tea/api.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from .build import (load_data, load_data_from_url, const,
                     ordinal, isordinal,
                     nominal, isnominal,
@@ -51,7 +53,7 @@ def data(file, key=None):
     global dataset_path, dataset_obj, dataset_id
 
     # Require that the path to the data must be a string or a Path object
-    assert (isinstance(file, str) or isinstance(file, Path))
+    assert isinstance(file, (str, Path, pd.DataFrame))
     dataset_path = file
     dataset_id = key
 
@@ -139,7 +141,12 @@ def hypothesize(vars: list, prediction: list = None):
     global assumptions, all_results
     global MODE
 
-    assert (dataset_path)
+    if isinstance(dataset_path, (str, Path)):
+        assert (dataset_path)
+    elif isinstance(dataset_path, pd.DataFrame):
+        assert not dataset_path.empty
+    else:
+        raise ValueError(f"dataset_path must be DataFrame, str, or Path. Not: {type(dataset_path)}")
     assert (vars_objs)
     assert (study_design)
 

--- a/tea/build.py
+++ b/tea/build.py
@@ -1,3 +1,7 @@
+from typing import Union
+
+import pandas as pd
+
 from tea.runtimeDataStructures.dataset import Dataset
 from tea.ast import (Variable, DataType, Literal, Relate, Relationship)
 
@@ -70,7 +74,7 @@ def iscategorical(var: Variable):
 
 
 # @param pid is the name of the column with participant ids
-def load_data(source_name: str, vars: list, pid: str):
+def load_data(source_name: Union[str, pd.DataFrame], vars: list, pid: str):
     return Dataset(source_name, vars, pid)
 
 

--- a/tea/runtimeDataStructures/dataset.py
+++ b/tea/runtimeDataStructures/dataset.py
@@ -58,8 +58,12 @@ class Dataset(object):
         return csv_path
 
     def __attrs_post_init__(self):
-        if self.dfile: 
+        if isinstance(self.dfile, (str, Path)):
             self.data = pd.read_csv(self.dfile)
+        elif isinstance(self.dfile, pd.DataFrame):
+            self.data = self.dfile
+        else:
+            raise ValueError(f"Dataset expected DataFrame, str, or Path. Received: {self.dfile}")
 
         # if self.pid_col_name:
         #     # Reindex DataFrame indices to be pids

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 import tea
 import os
 
@@ -572,6 +574,43 @@ def test_chi_square():
     }
 
     tea.data(data_path)
+    tea.define_variables(variables)
+    tea.define_study_design(experimental_design) # Allows for using multiple study designs for the same dataset (could lead to phishing but also practical for saving analyses and reusing as many parts of analyses as possible)
+    tea.assume(assumptions)
+
+    tea.hypothesize(['Training', 'Dance'])
+    # print('Chi square')
+    print('++++++++++++')
+
+
+def test_chi_square_with_dataframe():
+    data_path = get_data_path('catsData.csv')
+
+    data_frame = pd.read_csv(data_path)
+
+    # Declare and annotate the variables of interest
+    variables = [
+        {
+            'name' : 'Training',
+            'data type' : 'nominal',
+            'categories' : ['Food as Reward', 'Affection as Reward']
+        },
+        {
+            'name' : 'Dance',
+            'data type' : 'nominal',
+            'categories' : ['Yes', 'No']
+        }
+    ]
+    experimental_design = {
+                            'study type': 'observational study',
+                            'contributor variables': 'Training',
+                            'outcome variables': 'Dance'
+                        }
+    assumptions = {
+        'Type I (False Positive) Error Rate': 0.05,
+    }
+
+    tea.data(data_frame)  # Passes data_frame instead of data_path
     tea.define_variables(variables)
     tea.define_study_design(experimental_design) # Allows for using multiple study designs for the same dataset (could lead to phishing but also practical for saving analyses and reusing as many parts of analyses as possible)
     tea.assume(assumptions)


### PR DESCRIPTION
Resolves Issue #19. This lets users pass a pandas Dataframe directly into tea.data(). This avoids situations where users would need to save a csv file before passing into tea.data().

A test named "test_chi_square_with_dataframe" was added to test loading directly from a DataFrame. All tests are passing. The Results of "test_chi_square" and "test_chi_square_with_dataframe" were manually reviewed and found to be the same.
