### PR TITLE
Remove depreciated test

### DIFF
--- a/tests/unit_tests/test_evaluate_helper_methods.py
+++ b/tests/unit_tests/test_evaluate_helper_methods.py
@@ -1,7 +1,0 @@
-from tea.evaluate_helper_methods import explanatory_strings_for_assumptions
-from tea.solver import Assumptions, Tests, assumptions_for_test
-
-def test_explanatory_string_for_assumptions():
-    for test in list(Tests):
-        if not test == Tests.NONE:
-            assert len(explanatory_strings_for_assumptions(assumptions_for_test(test)))


### PR DESCRIPTION
`explanatory_strings_for_assumptions` method was removed from the codebase ([here](https://github.com/emjun/tea-lang/commit/59b3d1cb9c87ed2d704e05252237bdbeeb757938#diff-af17a37a7b747e74501658da728cfa49)) but the test remained. This might cause overall testing failures with the following error `ModuleNotFoundError: No module named 'tea.evaluate_helper_methods'`