### PR TITLE
Introduce code coverage for tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ install: "make"
 
 script: 
   - make test
-
+  
 before_install:
   - "pip install -U pip"
   - "python setup.py install"
+
+after_success:
+  - "coveralls"

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ init:
 	pipenv install --dev
 
 test:
-	pipenv run pytest ./tests/
+	pipenv run pytest --cov=tea ./tests/

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 parameterized = "*"
+pytest-cov ="*"
+coveralls = "*"
 
 [packages]
 attrs = "*"


### PR DESCRIPTION
This PR introduces code coverage check for the tests. 
Code coverage gives important understanding on which parts of the system require more testing and therefore can improve quality of the project.

To start gathering coverage, it should be enough to register the application on https://coveralls.io.

After this is enabled, we can embed a badge in README to indicate the coverage. It would look similar to 
[![Coverage Status](https://coveralls.io/repos/github/MaLiN2223/tea-lang/badge.svg?branch=create_coverage)](https://coveralls.io/github/MaLiN2223/tea-lang?branch=create_coverage)


Note: this PR requires #34 to be merged first. 