### PR TITLE
Move out test names to a separate file. 

### DIFF
--- a/tea/global_vals.py
+++ b/tea/global_vals.py
@@ -56,20 +56,3 @@ def log(message: str):
 def log_debug(message: str):
     print(message)
     # pass
-
-# Test names.
-pearson_name = "Pearson Correlation"
-kendalltau_name = "Kendall\'s Tau Correlation"
-spearman_name = "Spearman\'s R Correlation"
-pointbiserial_name = "Pointbiserial Correlation"
-students_t_name = "Student\'s T Test"
-paired_students_name = "Paired Student\'s T Test"
-welchs_t_name = "Welch\'s T Test"
-mann_whitney_name = "Mann Whitney U Test"
-wilcoxon_signed_rank_name = "Wilcoxon Signed Rank Test"
-rm_one_way_anova_name = "Repeated Measures One Way ANOVA"
-factorial_anova_name = "Factorial ANOVA"
-kruskall_wallis_name = "Kruskall Wallis"
-f_test_name = "F Test"
-chi_square_name = "Chi Square Test"
-fisher_exact_name = "Fisher\'s Exact Test"

--- a/tea/helpers/constants/test_names.py
+++ b/tea/helpers/constants/test_names.py
@@ -1,0 +1,17 @@
+# TODO: use final (https://docs.python.org/3/library/typing.html#typing.Final) after migrating to python 3.8 or newer
+
+PEARSON_NAME = "Pearson Correlation"
+KENDALLTAU_NAME = "Kendall\'s Tau Correlation"
+SPEARMAN_NAME = "Spearman\'s R Correlation"
+POINTBISERIAL_NAME = "Pointbiserial Correlation"
+STUDENTS_T_NAME = "Student\'s T Test"
+PAIRED_STUDENTS_NAME = "Paired Student\'s T Test"
+WELCHS_T_NAME = "Welch\'s T Test"
+MANN_WHITNEY_NAME = "Mann Whitney U Test"
+WILCOXON_SIGNED_RANK_NAME = "Wilcoxon Signed Rank Test"
+RM_ONE_WAY_ANOVA_NAME = "Repeated Measures One Way ANOVA"
+FACTORIAL_ANOVA_NAME = "Factorial ANOVA"
+KRUSKALL_WALLIS_NAME = "Kruskall Wallis"
+F_TEST_NAME = "F Test"
+CHI_SQUARE_NAME = "Chi Square Test"
+FISHER_EXACT_NAME = "Fisher\'s Exact Test"

--- a/tea/helpers/evaluateHelperMethods.py
+++ b/tea/helpers/evaluateHelperMethods.py
@@ -1,5 +1,6 @@
 # Tea
 from tea.global_vals import *
+from tea.helpers.constants.test_names import *
 from tea.ast import DataType, LessThan, GreaterThan
 from tea.runtimeDataStructures.dataset import Dataset
 from tea.runtimeDataStructures.varData import VarData
@@ -356,7 +357,7 @@ def students_t(dataset, predictions, combined_data: BivariateData):
 
     dof = len(lhs) + len(rhs) - 2 # Group1 + Group2 - 2
     test_result = TestResult(
-                        name = students_t_name,
+                        name = STUDENTS_T_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -394,7 +395,7 @@ def paired_students_t(dataset, predictions, combined_data: CombinedData):
     t_stat, p_val = stats.ttest_rel(data[0], data[1])
     dof = (len(data[0]) + len(data[1]))/2. - 1 # (Group1 + Group2)/2 - 1
     test_result = TestResult(
-                        name = paired_students_name,
+                        name = PAIRED_STUDENTS_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -443,7 +444,7 @@ def welchs_t(dataset, predictions, combined_data: BivariateData):
     else:
         dof = len(data[1]) - 1
     test_result = TestResult(
-                        name = welchs_t_name,
+                        name = WELCHS_T_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -484,7 +485,7 @@ def mannwhitney_u(dataset, predictions, combined_data: BivariateData):
     t_stat, p_val = stats.mannwhitneyu(data[0], data[1], alternative='two-sided')
     dof = len(data[0]) # TODO This might not be correct
     test_result = TestResult(
-                        name = mann_whitney_name,
+                        name = MANN_WHITNEY_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -520,7 +521,7 @@ def wilcoxon_signed_rank(dataset: Dataset, predictions, combined_data: CombinedD
     t_stat, p_val = stats.wilcoxon(data[0], data[1])
     dof = len(data[0]) # TODO This might not be correct
     test_result = TestResult(
-                        name = wilcoxon_signed_rank_name,
+                        name = WILCOXON_SIGNED_RANK_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -554,7 +555,7 @@ def pearson_corr(dataset: Dataset, predictions, combined_data: CombinedData):
     t_stat, p_val = stats.pearsonr(data[0], data[1])
     dof = None
     test_result = TestResult(
-                        name = pearson_name,
+                        name = PEARSON_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -592,7 +593,7 @@ def spearman_corr(dataset: Dataset, predictions, combined_data: CombinedData):
     t_stat, p_val = stats.spearmanr(data[0], data[1])
     dof = None
     test_result = TestResult(
-                        name = spearman_name,
+                        name = SPEARMAN_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -621,7 +622,7 @@ def kendalltau_corr(dataset: Dataset, predictions, combined_data: CombinedData):
     t_stat, p_val = stats.kendalltau(data[0], data[1])
     dof = None
     test_result = TestResult(
-                        name = kendalltau_name,
+                        name = KENDALLTAU_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -655,7 +656,7 @@ def pointbiserial(dataset: Dataset, predictions, combined_data: CombinedData):
     t_stat, p_val = stats.pointbiserialr(data[0], data[1])
     dof = None
     test_result = TestResult(
-                        name = pointbiserial_name,
+                        name = POINTBISERIAL_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,
@@ -718,7 +719,7 @@ def chi_square(dataset: Dataset, predictions, combined_data: CombinedData):
     test_statistic, p_val, dof, ex = stats.chi2_contingency(contingency_table, correction=False)
     dof = None
     test_result = TestResult(
-                        name = chi_square_name,
+                        name = CHI_SQUARE_NAME,
                         test_statistic = test_statistic,
                         p_value = p_val,
                         prediction = prediction,
@@ -781,7 +782,7 @@ def fishers_exact(dataset: Dataset, predictions, combined_data: CombinedData):
     odds_ratio, p_val = stats.fisher_exact(contingency_table, alternative='two-sided')
     dof = None
     test_result = TestResult(
-                        name = fisher_exact_name,
+                        name = FISHER_EXACT_NAME,
                         test_statistic = odds_ratio,
                         p_value = p_val,
                         prediction = prediction,
@@ -824,7 +825,7 @@ def f_test(dataset: Dataset, predictions, combined_data: CombinedData):
             dof = row_data['df']
 
     test_result = TestResult(
-                        name = f_test_name,
+                        name = F_TEST_NAME,
                         test_statistic = test_statistic,
                         p_value = p_val,
                         prediction = prediction,
@@ -902,7 +903,7 @@ def factorial_ANOVA(dataset: Dataset, predictions, combined_data: CombinedData):
             dof = row_data['df']
 
     test_result = TestResult(
-                        name = factorial_anova_name,
+                        name = FACTORIAL_ANOVA_NAME,
                         test_statistic = test_statistic,
                         p_value = p_val,
                         prediction = prediction,
@@ -952,7 +953,7 @@ def rm_one_way_anova(dataset: Dataset, predictions, design, combined_data: Combi
             dof = (row_data['Num DF'], row_data['Den DF'])
 
     test_result = TestResult(
-                        name = rm_one_way_anova_name,
+                        name = RM_ONE_WAY_ANOVA_NAME,
                         test_statistic = test_statistic,
                         p_value = p_val,
                         prediction = prediction,
@@ -990,7 +991,7 @@ def kruskall_wallis(dataset: Dataset, predictions, combined_data: CombinedData):
     t_stat, p_val = stats.kruskal(*data)
     dof = len(data[0]) # TODO This might not be correct
     test_result = TestResult(
-                        name = kruskall_wallis_name,
+                        name = KRUSKALL_WALLIS_NAME,
                         test_statistic = t_stat,
                         p_value = p_val,
                         prediction = prediction,

--- a/tea/runtimeDataStructures/testResult.py
+++ b/tea/runtimeDataStructures/testResult.py
@@ -1,4 +1,5 @@
 from tea.global_vals import *
+from tea.helpers.constants.test_names import *
 from enum import Enum
 from .value import Value
 from tea.ast import DataType, LessThan, GreaterThan, Literal, Relationship
@@ -13,70 +14,70 @@ group2 = None
 outcome = None
 
 __test_to_statistic_of_interest__ = {
-    students_t_name: "mean",
-    welchs_t_name: "mean",
-    mann_whitney_name: "median",
-    paired_students_name: "mean",
-    wilcoxon_signed_rank_name: "median",
-    kruskall_wallis_name: "median",
-    factorial_anova_name: "mean",
+    STUDENTS_T_NAME: "mean",
+    WELCHS_T_NAME: "mean",
+    MANN_WHITNEY_NAME: "median",
+    PAIRED_STUDENTS_NAME: "mean",
+    WILCOXON_SIGNED_RANK_NAME: "median",
+    KRUSKALL_WALLIS_NAME: "median",
+    FACTORIAL_ANOVA_NAME: "mean",
 }
 
 __stats_tests_to_null_hypotheses__ = {
-    pearson_name:  'There is no relationship between {} and {}.',
-    kendalltau_name: 'There is no relationship between {} and {}.',
-    spearman_name: 'There is no monotonic relationship between {} and {}.',
-    pointbiserial_name: 'There is no association between {} and {}.',
+    PEARSON_NAME:  'There is no relationship between {} and {}.',
+    KENDALLTAU_NAME: 'There is no relationship between {} and {}.',
+    SPEARMAN_NAME: 'There is no monotonic relationship between {} and {}.',
+    POINTBISERIAL_NAME: 'There is no association between {} and {}.',
 
-    students_t_name : 'There is no difference in {}s between {} and {} on {}.',
-    welchs_t_name : 'There is no difference in {}s between {} and {} on {}.',
-    mann_whitney_name : 'There is no difference in {}s between {} and {} on {}.',
-    paired_students_name : 'There is no difference in {}s between {} and {} on {}.',
-    wilcoxon_signed_rank_name : 'There is no difference in {}s between {} and {} on {}.',
+    STUDENTS_T_NAME : 'There is no difference in {}s between {} and {} on {}.',
+    WELCHS_T_NAME : 'There is no difference in {}s between {} and {} on {}.',
+    MANN_WHITNEY_NAME : 'There is no difference in {}s between {} and {} on {}.',
+    PAIRED_STUDENTS_NAME : 'There is no difference in {}s between {} and {} on {}.',
+    WILCOXON_SIGNED_RANK_NAME : 'There is no difference in {}s between {} and {} on {}.',
 
-    chi_square_name : 'There is no association between {} and {} on {}.',
-    fisher_exact_name : 'There is no association between {} and {} on {}.',
+    CHI_SQUARE_NAME : 'There is no association between {} and {} on {}.',
+    FISHER_EXACT_NAME : 'There is no association between {} and {} on {}.',
 
     # Regression or anova?
-    f_test_name : 'The variances of the groups ({}) are{}equal.',
-    kruskall_wallis_name : 'There is no difference in {}s between {} on {}.',
+    F_TEST_NAME : 'The variances of the groups ({}) are{}equal.',
+    KRUSKALL_WALLIS_NAME : 'There is no difference in {}s between {} on {}.',
     # This isn't very descriptive…
     "Friedman" : f'There is no difference between the groups',
-    factorial_anova_name : 'There is no difference in {}s between {} on {}.',
-    rm_one_way_anova_name : 'The means of all groups/conditions ({}) are{}equal.',
+    FACTORIAL_ANOVA_NAME : 'There is no difference in {}s between {} on {}.',
+    RM_ONE_WAY_ANOVA_NAME : 'The means of all groups/conditions ({}) are{}equal.',
 
     # Does this depend on the statistic being calculated?
     "Bootstrap" : f''
 }
 
 __two_group_tests__ = {
-    pearson_name,
-    kendalltau_name,
-    spearman_name,
-    pointbiserial_name,
+    PEARSON_NAME,
+    KENDALLTAU_NAME,
+    SPEARMAN_NAME,
+    POINTBISERIAL_NAME,
 }
 
 __two_group_outcome_tests__ = {
-    students_t_name,
-    welchs_t_name,
-    mann_whitney_name,
-    paired_students_name,
-    wilcoxon_signed_rank_name,
+    STUDENTS_T_NAME,
+    WELCHS_T_NAME,
+    MANN_WHITNEY_NAME,
+    PAIRED_STUDENTS_NAME,
+    WILCOXON_SIGNED_RANK_NAME,
 }
 
 __categorical_tests__ = {
-    chi_square_name,
-    fisher_exact_name,
+    CHI_SQUARE_NAME,
+    FISHER_EXACT_NAME,
 }
 
 __many_groups_test__ = {
-    rm_one_way_anova_name,
-    f_test_name,
+    RM_ONE_WAY_ANOVA_NAME,
+    F_TEST_NAME,
 }
 
 __many_groups_outcome_tests__ = {
-    kruskall_wallis_name,
-    factorial_anova_name,
+    KRUSKALL_WALLIS_NAME,
+    FACTORIAL_ANOVA_NAME,
 }
 
 


### PR DESCRIPTION
This PR is inspired by [python's zen](https://www.python.org/dev/peps/pep-0020/): 
> Namespaces are one honking great idea -- let's do more of those!

Hence, I have created a separate namespace for test names. I believe this will make imports more clear and explicit. In my opinion typing `from tea.helpers.constants.test_names import PEARSON_NAME` gives more context than `from tea.global_vals import PEARSON_NAME`
In addition, this is a first step towards improving (removing) the dependency on global variables. 

You might notice that I have renamed all variables to UPPER_CASE, this is to be inline with [PEP8 guidance](https://www.python.org/dev/peps/pep-0008/#constants) on constant values:

> Constants are usually defined on a module level and written in all capital letters with underscores separating words. Examples include MAX_OVERFLOW and TOTAL.

