### PR TITLE
Adding tests for evaluate method

### DIFF
--- a/tea/evaluate.py
+++ b/tea/evaluate.py
@@ -12,7 +12,7 @@ from tea.helpers.evaluateHelperMethods import determine_study_type, assign_roles
 from tea.z3_solver.solver import synthesize_tests
 
 import attr
-from typing import Any
+from typing import Any, Optional
 from types import SimpleNamespace # allows for dot notation access for dictionaries
 from typing import Dict
 
@@ -24,7 +24,7 @@ import pandas as pd
 
 
 # TODO: Pass participant_id as part of experimental design, not load_data
-def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: Dict[str, str]=None):
+def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: Dict[str, str]=None) -> Optional[VarData]:
     if isinstance(expr, Variable):
         # dataframe = dataset[expr.name] # I don't know if we want this. We may want to just store query (in metadata?) and
         # then use query to get raw data later....(for user, not interpreter?)
@@ -42,7 +42,7 @@ def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: 
         metadata['var_name'] = '' # because not a var in the dataset 
         metadata['query'] = ''
         metadata['value'] = expr.value
-        return VarData(data, metadata)
+        return VarData(metadata, data)
 
     elif isinstance(expr, Equal):
         lhs = evaluate(dataset, expr.lhs)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,58 @@
+from tea.runtimeDataStructures.varData import VarData
+from tea.ast import Literal, Variable
+from tea.runtimeDataStructures.dataset import Dataset
+import unittest
+from unittest.mock import Mock
+import pandas as pd
+from tea.evaluate import evaluate
+
+
+class EvaluateTests(unittest.TestCase):
+
+    def test_vardata_created_for_variable(self):
+        dataset = Mock(spec=Dataset)
+        mocked_variable_data = {}
+        dataset.get_variable_data.return_value = mocked_variable_data
+        expression = Mock(spec=Variable)
+        expression.name = ''
+
+        # ACT
+        returned_value = evaluate(dataset, expression, {})
+
+        # ASSERT
+        self.assertIsInstance(returned_value, VarData)
+
+    def test_vardata_has_correct_metadata_for_variable(self):
+
+        mocked_variable_data = {}
+        mocked_expression_name = 'expr-name'
+
+        dataset = Mock(spec=Dataset)
+        dataset.get_variable_data.return_value = mocked_variable_data
+
+        expression = Mock(spec=Variable)
+        expression.name = mocked_expression_name
+
+        # ACT
+        returned_value = evaluate(dataset, expression, {})
+
+        # ASSERT
+        self.assertTrue('var_name' in returned_value.metadata)
+        self.assertEqual(returned_value.metadata['var_name'], mocked_expression_name)
+
+    def test_vardata_has_correct_metadata_for_literal(self):
+        mocked_expression_value = 'expression value'
+        data_for_dataset = [1, 2, 3]
+        dataset = Mock(spec=Dataset)
+
+        dataset.data = pd.Series(data_for_dataset)
+        expression = Mock(spec=Literal)
+        expression.value = mocked_expression_value
+
+        # ACT
+        returned_value = evaluate(dataset, expression, {})
+
+        # ASSERT
+        self.assertTrue('value' in returned_value.metadata)
+        self.assertEqual(returned_value.metadata['value'], mocked_expression_value)
+        self.assertEqual(len(returned_value.properties), len(data_for_dataset))


### PR DESCRIPTION
This PR adds some basic tests for `evaluate` funciton. This might make it easier for future contributors to expand/change this method.

Also, I think I have noticed a bug as documented in `test_vardata_has_correct_metadata_for_literal`, I think the arguments were passed in incorrect order.
