### PR TITLE
[Proposal] Refactor evaluate method

### DIFF
--- a/tea/api.py
+++ b/tea/api.py
@@ -8,7 +8,7 @@ from .build import (load_data, load_data_from_url, const,
                     select, compare, relate, predict,
                     get_var_from_list
                     )
-from .evaluate import evaluate
+from .vardata_factory import VarDataFactory
 import tea.helpers
 import tea.runtimeDataStructures
 import tea.z3_solver
@@ -163,7 +163,8 @@ def hypothesize(vars: list, prediction: list = None):
     # Interpret AST node, Returns ResultData object <-- this may need to change
     set_mode(MODE)
     num_comparisons = 1
-    result = evaluate(dataset_obj, relationship, assumptions, study_design)
+    vardata_factory = VarDataFactory()
+    result = vardata_factory.create_vardata(dataset_obj, relationship, assumptions, study_design)
 
     # Make multiple comparison correction
     result.bonferroni_correction(num_comparisons)

--- a/tea/vardata_factory.py
+++ b/tea/vardata_factory.py
@@ -1,8 +1,8 @@
-from tea.ast import (   Node, Variable, Literal, 
-                        Equal, NotEqual, LessThan, 
-                        LessThanEqual, GreaterThan, GreaterThanEqual,
-                        Relate, PositiveRelationship
-                    )
+from tea.ast import (Node, Variable, Literal,
+                     Equal, NotEqual, LessThan,
+                     LessThanEqual, GreaterThan, GreaterThanEqual,
+                     Relate, PositiveRelationship
+                     )
 from tea.runtimeDataStructures.dataset import Dataset
 from tea.runtimeDataStructures.varData import VarData
 from tea.runtimeDataStructures.bivariateData import BivariateData
@@ -11,145 +11,118 @@ from tea.runtimeDataStructures.resultData import ResultData
 from tea.helpers.evaluateHelperMethods import determine_study_type, assign_roles, add_paired_property, execute_test
 from tea.z3_solver.solver import synthesize_tests
 
-import attr
-from typing import Any, Optional
-from types import SimpleNamespace # allows for dot notation access for dictionaries
+from typing import Optional
 from typing import Dict
 
-from scipy import stats # Stats library used
-import statsmodels.api as sm
-import statsmodels.formula.api as smf
-import numpy as np # Use some stats from numpy instead
+import numpy as np  # Use some stats from numpy instead
 import pandas as pd
 
 
-# TODO: Pass participant_id as part of experimental design, not load_data
-def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: Dict[str, str]=None) -> Optional[VarData]:
-    if isinstance(expr, Variable):
+class VarDataFactory:
+
+    # TODO: Pass participant_id as part of experimental design, not load_data
+    def create_vardata(self, dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: Optional[Dict[str, str]] = None) -> Optional[VarData]:
+        if isinstance(expr, Variable):
+            return self.__create_variable_vardata(dataset, expr)
+
+        elif isinstance(expr, Literal):
+            return self.__create_literal_vardata(dataset, expr)
+
+        elif isinstance(expr, Equal):
+            return self.__create_equal_vardata(dataset, expr, assumptions, design)
+
+        elif isinstance(expr, NotEqual):
+            return self.__create_not_equal_vardata(dataset, expr, assumptions, design)
+
+        elif isinstance(expr, LessThan):
+            return self.__create_less_than_vardata(dataset, expr, assumptions, design)
+
+        elif isinstance(expr, LessThanEqual):
+            return self.__create_less_than_equal_vardata(dataset, expr, assumptions, design)
+
+        elif isinstance(expr, GreaterThan):
+            return self.__create_greater_than_vardata(dataset, expr, assumptions, design)
+
+        elif isinstance(expr, GreaterThanEqual):
+            return self.__create_greater_than_equal_vardata(dataset, expr, assumptions, design)
+
+        elif isinstance(expr, Relate):
+            return self.__create_relate_vardata(dataset, expr, assumptions, design)
+
+        elif isinstance(expr, PositiveRelationship):
+            return self.__create_positive_relationship_vardata(dataset, expr, assumptions, design)
+
+        # elif isinstance(expr, Relationship):
+        #     import pdb; pdb.set_trace()
+
+        # elif isinstance(expr, Mean):
+        #     var = self.create_vardata(dataset, expr.var)
+        #     assert isinstance(var, VarData)
+
+        #     # bs.bootstrap(var.dataframe, stat_func=
+        #     # bs_stats.mean)
+
+        #     raise Exception('Not implemented Mean')
+
+    def __create_variable_vardata(self, dataset: Dataset, expr: Variable) -> VarData:
         # dataframe = dataset[expr.name] # I don't know if we want this. We may want to just store query (in metadata?) and
         # then use query to get raw data later....(for user, not interpreter?)
-        metadata = dataset.get_variable_data(expr.name) # (dtype, categories)
+        metadata = dataset.get_variable_data(expr.name)  # (dtype, categories)
         # if expr.name == 'strategy':
         #     import pdb; pdb.set_trace()
         metadata['var_name'] = expr.name
         metadata['query'] = ''
         return VarData(metadata)
 
-    elif isinstance(expr, Literal):
-        data = pd.Series([expr.value] * len(dataset.data), index=dataset.data.index) # Series filled with literal value
+    def __create_literal_vardata(self, dataset: Dataset, expr: Literal) -> VarData:
+        data = pd.Series([expr.value] * len(dataset.data), index=dataset.data.index)  # Series filled with literal value
         # metadata = None # metadata=None means literal
-        metadata = dict() # metadata=None means literal
-        metadata['var_name'] = '' # because not a var in the dataset 
+        metadata = dict()  # metadata=None means literal
+        metadata['var_name'] = ''  # because not a var in the dataset
         metadata['query'] = ''
         metadata['value'] = expr.value
         return VarData(metadata, data)
 
-    elif isinstance(expr, Equal):
-        lhs = evaluate(dataset, expr.lhs)
-        rhs = evaluate(dataset, expr.rhs)
+    def __create_equal_vardata(self, dataset: Dataset, expr: Equal, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> VarData:
+        lhs = self.create_vardata(dataset, expr.lhs, assumptions, design)
+        rhs = self.create_vardata(dataset, expr.rhs, assumptions, design)
         assert isinstance(lhs, VarData)
         assert isinstance(rhs, VarData)
-        
-        
-        dataframe = lhs.dataframe[lhs.dataframe == rhs.dataframe]
+
         metadata = lhs.metadata
         if (isinstance(expr.rhs, Literal)):
-            metadata['query'] = f" == \'{rhs.metadata['value']}\'" # override lhs metadata for query
-        elif (isinstance(expr.rhs, Variable)): 
+            metadata['query'] = f" == \'{rhs.metadata['value']}\'"  # override lhs metadata for query
+        elif (isinstance(expr.rhs, Variable)):
             metadata['query'] = f" == {rhs.metadata['var_name']}"
-        else: 
+        else:
             raise ValueError(f"Not implemented for {rhs}")
-        
+
         return VarData(metadata)
 
-    elif isinstance(expr, NotEqual): 
-        rhs = evaluate(dataset, expr.rhs)
-        lhs = evaluate(dataset, expr.lhs)
+    def __create_not_equal_vardata(self, dataset: Dataset, expr: NotEqual, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> VarData:
+        rhs = self.create_vardata(dataset, expr.rhs, assumptions, design)
+        lhs = self.create_vardata(dataset, expr.lhs, assumptions, design)
         assert isinstance(rhs, VarData)
         assert isinstance(lhs, VarData)
-        
-        dataframe = lhs.dataframe[lhs.dataframe != rhs.dataframe]
+
         metadata = lhs.metadata
         if (isinstance(expr.rhs, Literal)):
-            metadata['query'] = " != \'\'" # override lhs metadata for query
-        elif (isinstance(expr.rhs, Variable)): 
+            metadata['query'] = " != \'\'"  # override lhs metadata for query
+        elif (isinstance(expr.rhs, Variable)):
             metadata['query'] = f" != {rhs.metadata['var_name']}"
-        else: 
-            raise ValueError(f"Not implemented for {rhs}")
-        return VarData(metadata)
-
-    elif isinstance(expr, LessThan):
-        lhs = evaluate(dataset, expr.lhs)
-        rhs = evaluate(dataset, expr.rhs)
-        assert isinstance(lhs, VarData)
-        assert isinstance(rhs, VarData)
-
-        dataframe = None
-        metadata = rhs.metadata
-        
-        if (not lhs.metadata):
-            raise ValueError('Malformed Relation. Filter on Variables must have variable as rhs')
-        elif (lhs.metadata['dtype'] is DataType.NOMINAL):
-            raise ValueError('Cannot compare nominal values with Less Than')
-        elif (lhs.metadata['dtype'] is DataType.ORDINAL):
-            # TODO May want to add a case should RHS and LHS both be variables
-            # assert (rhs.metadata is None) 
-            comparison = rhs.dataframe.iloc[0]
-            if (isinstance(comparison, str)):
-                categories = lhs.metadata['categories'] # OrderedDict
-                # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] < categories[comparison]]
-                # Get Pandas Series set indices for desired data
-                p_ids = [lhs.dataframe.index.values[i] for i in ids]
-                # Create new Pandas Series with only the desired data, using set indices
-                dataframe = pd.Series(lhs.dataframe, p_ids)
-                dataframe.index.name = dataset.pid_col_name
-                
-            elif (np.issubdtype(comparison, np.integer)):
-                categories = lhs.metadata['categories'] # OrderedDict
-                # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] < comparison]
-                # Get Pandas Series set indices for desired data
-                p_ids = [lhs.dataframe.index.values[i] for i in ids]
-                # Create new Pandas Series with only the desired data, using set indices
-                dataframe = pd.Series(lhs.dataframe, p_ids)
-                dataframe.index.name = dataset.pid_col_name                
-
-            else: 
-                raise ValueError(f"Cannot compare ORDINAL variables to {type(rhs.dataframe.iloc[0])}")
-
-
-        elif (lhs.metadata['dtype'] is DataType.INTERVAL or lhs.metadata['dtype'] is DataType.RATIO):
-            comparison = rhs.dataframe.iloc[0]
-             # Get raw Pandas Series indices for desired data
-            ids  = [i for i,x in enumerate(lhs.dataframe) if x < comparison]
-            # Get Pandas Series set indices for desired data
-            p_ids = [lhs.dataframe.index.values[i] for i in ids]
-            # Create new Pandas Series with only the desired data, using set indices
-            dataframe = pd.Series(lhs.dataframe, p_ids)
-            dataframe.index.name = dataset.pid_col_name   
-
         else:
-            raise Exception(f"Invalid Less Than Operation:{lhs} < {rhs}")
-
-        if (isinstance(expr.rhs, Literal)):
-            metadata['query'] = " < \'\'" # override lhs metadata for query
-        elif (isinstance(expr.rhs, Variable)): 
-            metadata['query'] = f" < {rhs.metadata['var_name']}"
-        else: 
             raise ValueError(f"Not implemented for {rhs}")
         return VarData(metadata)
 
-    elif isinstance(expr, LessThanEqual):
-        lhs = evaluate(dataset, expr.lhs)
-        rhs = evaluate(dataset, expr.rhs)
+    def __create_less_than_vardata(self,  dataset: Dataset, expr: LessThan, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> VarData:
+        lhs = self.create_vardata(dataset, expr.lhs, assumptions, design)
+        rhs = self.create_vardata(dataset, expr.rhs, assumptions, design)
         assert isinstance(lhs, VarData)
         assert isinstance(rhs, VarData)
 
-
         dataframe = None
         metadata = rhs.metadata
-        
+
         if (not lhs.metadata):
             raise ValueError('Malformed Relation. Filter on Variables must have variable as rhs')
         elif (lhs.metadata['dtype'] is DataType.NOMINAL):
@@ -159,187 +132,239 @@ def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: 
             # assert (rhs.metadata is None)
             comparison = rhs.dataframe.iloc[0]
             if (isinstance(comparison, str)):
-                categories = lhs.metadata['categories'] # OrderedDict
+                categories = lhs.metadata['categories']  # OrderedDict
                 # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] <= categories[comparison]]
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] < categories[comparison]]
                 # Get Pandas Series set indices for desired data
                 p_ids = [lhs.dataframe.index.values[i] for i in ids]
                 # Create new Pandas Series with only the desired data, using set indices
                 dataframe = pd.Series(lhs.dataframe, p_ids)
                 dataframe.index.name = dataset.pid_col_name
-                
+
             elif (np.issubdtype(comparison, np.integer)):
-                categories = lhs.metadata['categories'] # OrderedDict
+                categories = lhs.metadata['categories']  # OrderedDict
                 # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] <= comparison]
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] < comparison]
                 # Get Pandas Series set indices for desired data
                 p_ids = [lhs.dataframe.index.values[i] for i in ids]
                 # Create new Pandas Series with only the desired data, using set indices
                 dataframe = pd.Series(lhs.dataframe, p_ids)
-                dataframe.index.name = dataset.pid_col_name                
+                dataframe.index.name = dataset.pid_col_name
 
-            else: 
+            else:
                 raise ValueError(f"Cannot compare ORDINAL variables to {type(rhs.dataframe.iloc[0])}")
-
 
         elif (lhs.metadata['dtype'] is DataType.INTERVAL or lhs.metadata['dtype'] is DataType.RATIO):
             comparison = rhs.dataframe.iloc[0]
-             # Get raw Pandas Series indices for desired data
-            ids  = [i for i,x in enumerate(lhs.dataframe) if x <= comparison]
+            # Get raw Pandas Series indices for desired data
+            ids = [i for i, x in enumerate(lhs.dataframe) if x < comparison]
             # Get Pandas Series set indices for desired data
             p_ids = [lhs.dataframe.index.values[i] for i in ids]
             # Create new Pandas Series with only the desired data, using set indices
             dataframe = pd.Series(lhs.dataframe, p_ids)
-            dataframe.index.name = dataset.pid_col_name   
+            dataframe.index.name = dataset.pid_col_name
+
+        else:
+            raise Exception(f"Invalid Less Than Operation:{lhs} < {rhs}")
+
+        if (isinstance(expr.rhs, Literal)):
+            metadata['query'] = " < \'\'"  # override lhs metadata for query
+        elif (isinstance(expr.rhs, Variable)):
+            metadata['query'] = f" < {rhs.metadata['var_name']}"
+        else:
+            raise ValueError(f"Not implemented for {rhs}")
+        return VarData(metadata)
+
+    def __create_less_than_equal_vardata(self,  dataset: Dataset, expr: LessThanEqual, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> VarData:
+        lhs = self.create_vardata(dataset, expr.lhs, assumptions, design)
+        rhs = self.create_vardata(dataset, expr.rhs, assumptions, design)
+        assert isinstance(lhs, VarData)
+        assert isinstance(rhs, VarData)
+
+        dataframe = None
+        metadata = rhs.metadata
+
+        if (not lhs.metadata):
+            raise ValueError('Malformed Relation. Filter on Variables must have variable as rhs')
+        elif (lhs.metadata['dtype'] is DataType.NOMINAL):
+            raise ValueError('Cannot compare nominal values with Less Than')
+        elif (lhs.metadata['dtype'] is DataType.ORDINAL):
+            # TODO May want to add a case should RHS and LHS both be variables
+            # assert (rhs.metadata is None)
+            comparison = rhs.dataframe.iloc[0]
+            if (isinstance(comparison, str)):
+                categories = lhs.metadata['categories']  # OrderedDict
+                # Get raw Pandas Series indices for desired data
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] <= categories[comparison]]
+                # Get Pandas Series set indices for desired data
+                p_ids = [lhs.dataframe.index.values[i] for i in ids]
+                # Create new Pandas Series with only the desired data, using set indices
+                dataframe = pd.Series(lhs.dataframe, p_ids)
+                dataframe.index.name = dataset.pid_col_name
+
+            elif (np.issubdtype(comparison, np.integer)):
+                categories = lhs.metadata['categories']  # OrderedDict
+                # Get raw Pandas Series indices for desired data
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] <= comparison]
+                # Get Pandas Series set indices for desired data
+                p_ids = [lhs.dataframe.index.values[i] for i in ids]
+                # Create new Pandas Series with only the desired data, using set indices
+                dataframe = pd.Series(lhs.dataframe, p_ids)
+                dataframe.index.name = dataset.pid_col_name
+
+            else:
+                raise ValueError(f"Cannot compare ORDINAL variables to {type(rhs.dataframe.iloc[0])}")
+
+        elif (lhs.metadata['dtype'] is DataType.INTERVAL or lhs.metadata['dtype'] is DataType.RATIO):
+            comparison = rhs.dataframe.iloc[0]
+            # Get raw Pandas Series indices for desired data
+            ids = [i for i, x in enumerate(lhs.dataframe) if x <= comparison]
+            # Get Pandas Series set indices for desired data
+            p_ids = [lhs.dataframe.index.values[i] for i in ids]
+            # Create new Pandas Series with only the desired data, using set indices
+            dataframe = pd.Series(lhs.dataframe, p_ids)
+            dataframe.index.name = dataset.pid_col_name
 
         else:
             raise Exception(f"Invalid Less Than Equal Operation:{lhs} <= {rhs}")
 
-
         if (isinstance(expr.rhs, Literal)):
-            metadata['query'] = " <= \'\'" # override lhs metadata for query
-        elif (isinstance(expr.rhs, Variable)): 
+            metadata['query'] = " <= \'\'"  # override lhs metadata for query
+        elif (isinstance(expr.rhs, Variable)):
             metadata['query'] = f" <= {rhs.metadata['var_name']}"
-        else: 
+        else:
             raise ValueError(f"Not implemented for {rhs}")
 
         return VarData(metadata)
-    
-    elif isinstance(expr, GreaterThan):
-        lhs = evaluate(dataset, expr.lhs)
-        rhs = evaluate(dataset, expr.rhs)
+
+    def __create_greater_than_vardata(self,  dataset: Dataset, expr: GreaterThan, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> VarData:
+        lhs = self.create_vardata(dataset, expr.lhs, assumptions, design)
+        rhs = self.create_vardata(dataset, expr.rhs, assumptions, design)
         assert isinstance(lhs, VarData)
         assert isinstance(rhs, VarData)
 
-
         dataframe = None
         metadata = rhs.metadata
-        
+
         if (not lhs.metadata):
             raise ValueError('Malformed Relation. Filter on Variables must have variable as rhs')
         elif (lhs.metadata['dtype'] is DataType.NOMINAL):
             raise ValueError('Cannot compare nominal values with Greater Than')
         elif (lhs.metadata['dtype'] is DataType.ORDINAL):
             # TODO May want to add a case should RHS and LHS both be variables
-            # assert (rhs.metadata is None) 
+            # assert (rhs.metadata is None)
             comparison = rhs.dataframe.iloc[0]
             if (isinstance(comparison, str)):
-                categories = lhs.metadata['categories'] # OrderedDict
+                categories = lhs.metadata['categories']  # OrderedDict
                 # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] > categories[comparison]]
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] > categories[comparison]]
                 # Get Pandas Series set indices for desired data
                 p_ids = [lhs.dataframe.index.values[i] for i in ids]
                 # Create new Pandas Series with only the desired data, using set indices
                 dataframe = pd.Series(lhs.dataframe, p_ids)
                 dataframe.index.name = dataset.pid_col_name
-                
+
             elif (np.issubdtype(comparison, np.integer)):
-                categories = lhs.metadata['categories'] # OrderedDict
+                categories = lhs.metadata['categories']  # OrderedDict
                 # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] > comparison]
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] > comparison]
                 # Get Pandas Series set indices for desired data
                 p_ids = [lhs.dataframe.index.values[i] for i in ids]
                 # Create new Pandas Series with only the desired data, using set indices
                 dataframe = pd.Series(lhs.dataframe, p_ids)
-                dataframe.index.name = dataset.pid_col_name                
+                dataframe.index.name = dataset.pid_col_name
 
-            else: 
+            else:
                 raise ValueError(f"Cannot compare ORDINAL variables to {type(rhs.dataframe.iloc[0])}")
-
 
         elif (lhs.metadata['dtype'] is DataType.INTERVAL or lhs.metadata['dtype'] is DataType.RATIO):
             comparison = rhs.dataframe.iloc[0]
-             # Get raw Pandas Series indices for desired data
-            ids  = [i for i,x in enumerate(lhs.dataframe) if x > comparison]
+            # Get raw Pandas Series indices for desired data
+            ids = [i for i, x in enumerate(lhs.dataframe) if x > comparison]
             # Get Pandas Series set indices for desired data
             p_ids = [lhs.dataframe.index.values[i] for i in ids]
             # Create new Pandas Series with only the desired data, using set indices
             dataframe = pd.Series(lhs.dataframe, p_ids)
-            dataframe.index.name = dataset.pid_col_name   
+            dataframe.index.name = dataset.pid_col_name
 
         else:
             raise Exception(f"Invalid Greater Than Operation:{lhs} > {rhs}")
 
         if (isinstance(expr.rhs, Literal)):
-            metadata['query'] = " > \'\'" # override lhs metadata for query
-        elif (isinstance(expr.rhs, Variable)): 
+            metadata['query'] = " > \'\'"  # override lhs metadata for query
+        elif (isinstance(expr.rhs, Variable)):
             metadata['query'] = f" > {rhs.metadata['var_name']}"
-        else: 
+        else:
             raise ValueError(f"Not implemented for {rhs}")
 
-        return VarData(metadata) 
-   
-    elif isinstance(expr, GreaterThanEqual):
-        lhs = evaluate(dataset, expr.lhs)
-        rhs = evaluate(dataset, expr.rhs)
+        return VarData(metadata)
+
+    def __create_greater_than_equal_vardata(self,  dataset: Dataset, expr: GreaterThanEqual, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> VarData:
+        lhs = self.create_vardata(dataset, expr.lhs, assumptions, design)
+        rhs = self.create_vardata(dataset, expr.rhs, assumptions, design)
         assert isinstance(lhs, VarData)
         assert isinstance(rhs, VarData)
 
-
         dataframe = None
         metadata = rhs.metadata
-        
+
         if (not lhs.metadata):
             raise ValueError('Malformed Relation. Filter on Variables must have variable as rhs')
         elif (lhs.metadata['dtype'] is DataType.NOMINAL):
             raise ValueError('Cannot compare nominal values with Greater Than Equal')
         elif (lhs.metadata['dtype'] is DataType.ORDINAL):
             # TODO May want to add a case should RHS and LHS both be variables
-            # assert (rhs.metadata is None) 
+            # assert (rhs.metadata is None)
             comparison = rhs.dataframe.iloc[0]
             if (isinstance(comparison, str)):
-                categories = lhs.metadata['categories'] # OrderedDict
+                categories = lhs.metadata['categories']  # OrderedDict
                 # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] >= categories[comparison]]
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] >= categories[comparison]]
                 # Get Pandas Series set indices for desired data
                 p_ids = [lhs.dataframe.index.values[i] for i in ids]
                 # Create new Pandas Series with only the desired data, using set indices
                 dataframe = pd.Series(lhs.dataframe, p_ids)
                 dataframe.index.name = dataset.pid_col_name
-                
+
             elif (np.issubdtype(comparison, np.integer)):
-                categories = lhs.metadata['categories'] # OrderedDict
+                categories = lhs.metadata['categories']  # OrderedDict
                 # Get raw Pandas Series indices for desired data
-                ids  = [i for i,x in enumerate(lhs.dataframe) if categories[x] >= comparison]
+                ids = [i for i, x in enumerate(lhs.dataframe) if categories[x] >= comparison]
                 # Get Pandas Series set indices for desired data
                 p_ids = [lhs.dataframe.index.values[i] for i in ids]
                 # Create new Pandas Series with only the desired data, using set indices
                 dataframe = pd.Series(lhs.dataframe, p_ids)
-                dataframe.index.name = dataset.pid_col_name                
+                dataframe.index.name = dataset.pid_col_name
 
-            else: 
+            else:
                 raise ValueError(f"Cannot compare ORDINAL variables to {type(rhs.dataframe.iloc[0])}")
-
 
         elif (lhs.metadata['dtype'] is DataType.INTERVAL or lhs.metadata['dtype'] is DataType.RATIO):
             comparison = rhs.dataframe.iloc[0]
-             # Get raw Pandas Series indices for desired data
-            ids  = [i for i,x in enumerate(lhs.dataframe) if x >= comparison]
+            # Get raw Pandas Series indices for desired data
+            ids = [i for i, x in enumerate(lhs.dataframe) if x >= comparison]
             # Get Pandas Series set indices for desired data
             p_ids = [lhs.dataframe.index.values[i] for i in ids]
             # Create new Pandas Series with only the desired data, using set indices
             dataframe = pd.Series(lhs.dataframe, p_ids)
-            dataframe.index.name = dataset.pid_col_name   
+            dataframe.index.name = dataset.pid_col_name
 
         else:
             raise Exception(f"Invalid Greater Than Equal Operation:{lhs} >= {rhs}")
-
-
         if (isinstance(expr.rhs, Literal)):
-            metadata['query'] = " >= \'\'" # override lhs metadata for query
-        elif (isinstance(expr.rhs, Variable)): 
+            metadata['query'] = " >= \'\'"  # override lhs metadata for query
+        elif (isinstance(expr.rhs, Variable)):
             metadata['query'] = f" >= {rhs.metadata['var_name']}"
-        else: 
+        else:
             raise ValueError(f"Not implemented for {rhs}")
-        return VarData(metadata) 
+        return VarData(metadata)
 
-    elif isinstance(expr, Relate):    
+    def __create_relate_vardata(self,  dataset: Dataset, expr: Relate, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> VarData:
         vars = []
+        for v in expr.vars:
+            eval_v = self.create_vardata(dataset, v, design)
 
-        for v in expr.vars: 
-            eval_v = evaluate(dataset, v, design)    
-            
-            if not eval_v: 
+            if not eval_v:
                 raise ValueError("The variables you are referencing are not defined as variables in your list of variables.")
             assert isinstance(eval_v, VarData)
 
@@ -350,21 +375,20 @@ def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: 
 
         # Assign roles to variables we are analyzing
         vars = assign_roles(vars, study_type, design)
-        
+
         combined_data = None
         # Do we have a Bivariate analysis?
-        if len(vars) == 2: 
-            combined_data = BivariateData(vars, study_type, alpha=float(assumptions['alpha'])) 
-        else: # Do we have a Multivariate analysis?
+        if len(vars) == 2:
+            combined_data = BivariateData(vars, study_type, alpha=float(assumptions['alpha']))
+        else:  # Do we have a Multivariate analysis?
             combined_data = MultivariateData(vars, study_type, alpha=float(assumptions['alpha']))
-        
+
         # Add paired property
-        add_paired_property(dataset, combined_data, study_type, design) # check sample sizes are identical
+        add_paired_property(dataset, combined_data, study_type, design)  # check sample sizes are identical
 
         # Infer stats tests (mingled with)
         tests = synthesize_tests(dataset, assumptions, combined_data)
-        
-    
+
         """"
         # verify_properties(properties_and_tests)
         # get_tests
@@ -386,29 +410,28 @@ def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: 
                         property_identifier += ": %s" % prop.name
                 print(property_identifier)
         """
-        
+
         # Execute and store results from each valid test
         results = {}
-        if len(tests) == 0: 
-            tests.append('bootstrap') # Default to bootstrap
+        if len(tests) == 0:
+            tests.append('bootstrap')  # Default to bootstrap
 
-        for test in tests: 
+        for test in tests:
             test_result = execute_test(dataset, design, expr.predictions, combined_data, test)
             results[test] = test_result
-        
-        
+
         res_data = ResultData(results, combined_data)
 
         follow_up = []
 
         # There are multiple hypotheses to follow-up and correct for
-        if expr.predictions and len(expr.predictions) > 1: 
-            for pred in expr.predictions: 
-                # create follow-up expr Node (to evaluate recursively)
-                pred_res = evaluate(dataset, pred, assumptions, design)
-                follow_up.append(pred_res) # add follow-up result to follow_up
-        
-        res_data.add_follow_up(follow_up) # add follow-up results to the res_data object
+        if expr.predictions and len(expr.predictions) > 1:
+            for pred in expr.predictions:
+                # create follow-up expr Node (to self.create_vardata recursively)
+                pred_res = self.create_vardata(dataset, pred, assumptions, design)
+                follow_up.append(pred_res)  # add follow-up result to follow_up
+
+        res_data.add_follow_up(follow_up)  # add follow-up results to the res_data object
         """
         # TODO: use a handle here to more generally/modularly support corrections, need a more generic data structure for this!
         if expr.predictions:
@@ -423,22 +446,10 @@ def evaluate(dataset: Dataset, expr: Node, assumptions: Dict[str, str], design: 
         # import pdb; pdb.set_trace()
         return res_data
 
-    elif isinstance(expr, PositiveRelationship):
+    def __create_positive_relationship_vardata(self,  dataset: Dataset, expr: PositiveRelationship, assumptions: Dict[str, str], design: Optional[Dict[str, str]]) -> Optional[VarData]:
         # get variables
         vars = [expr.lhs.var, expr.rhs.var]
 
         # create a Relate object
         pos_relate_expr = Relate(vars)
-        return evaluate(dataset, pos_relate_expr, assumptions, design)
-
-    # elif isinstance(expr, Relationship):
-    #     import pdb; pdb.set_trace()
-        
-    # elif isinstance(expr, Mean):
-    #     var = evaluate(dataset, expr.var)
-    #     assert isinstance(var, VarData)
-
-    #     # bs.bootstrap(var.dataframe, stat_func=
-    #     # bs_stats.mean)
-
-    #     raise Exception('Not implemented Mean')
+        return self.create_vardata(dataset, pos_relate_expr, assumptions, design)

--- a/tests/test_vardata_factory.py
+++ b/tests/test_vardata_factory.py
@@ -1,13 +1,15 @@
 from tea.runtimeDataStructures.varData import VarData
-from tea.ast import Literal, Variable
+from tea.ast import Literal, Node, Variable
 from tea.runtimeDataStructures.dataset import Dataset
 import unittest
 from unittest.mock import Mock
 import pandas as pd
-from tea.evaluate import evaluate
+from tea.vardata_factory import VarDataFactory
 
 
-class EvaluateTests(unittest.TestCase):
+class VarDataFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.varadata_factory = VarDataFactory()
 
     def test_vardata_created_for_variable(self):
         dataset = Mock(spec=Dataset)
@@ -17,7 +19,7 @@ class EvaluateTests(unittest.TestCase):
         expression.name = ''
 
         # ACT
-        returned_value = evaluate(dataset, expression, {})
+        returned_value = self.varadata_factory.create_vardata(dataset, expression, {})
 
         # ASSERT
         self.assertIsInstance(returned_value, VarData)
@@ -34,7 +36,7 @@ class EvaluateTests(unittest.TestCase):
         expression.name = mocked_expression_name
 
         # ACT
-        returned_value = evaluate(dataset, expression, {})
+        returned_value = self.varadata_factory.create_vardata(dataset, expression, {})
 
         # ASSERT
         self.assertTrue('var_name' in returned_value.metadata)
@@ -50,9 +52,19 @@ class EvaluateTests(unittest.TestCase):
         expression.value = mocked_expression_value
 
         # ACT
-        returned_value = evaluate(dataset, expression, {})
+        returned_value = self.varadata_factory.create_vardata(dataset, expression, {})
 
         # ASSERT
         self.assertTrue('value' in returned_value.metadata)
         self.assertEqual(returned_value.metadata['value'], mocked_expression_value)
         self.assertEqual(len(returned_value.properties), len(data_for_dataset))
+
+    def test_should_return_none_for_unknown_node(self):
+        dataset = Mock(spec=Dataset)
+        expression = Mock(spec=Node)
+
+        # ACT
+        returned_value = self.varadata_factory.create_vardata(dataset, expression, {})
+
+        # ASSERT
+        self.assertIsNone(returned_value)


### PR DESCRIPTION
This PR introduces four changes
1. Extracts `evaluate` method to a class that implements factory pattern
2. Renames method to indicate what action it is doing - creates VarData. I don't have strong feelings towards this change, so I am very happy to roll this back.
3. Splits this method into multiple smaller ones - in my opinions this will improve readability and testability.
4. Fix #42 