### PR TITLE
Adding more tests for build + bugfix

### DIFF
--- a/tea/api.py
+++ b/tea/api.py
@@ -166,7 +166,8 @@ def hypothesize(vars: list, prediction: list = None):
     # Interpret AST node, Returns ResultData object <-- this may need to change
     set_mode(MODE)
     num_comparisons = 1
-    vardata_factory = VarDataFactory()
+    study_type_determiner = StudyTypeDeterminer()
+    vardata_factory = VarDataFactory(study_type_determiner)
     result = vardata_factory.create_vardata(dataset_obj, relationship, assumptions, study_design)
 
     # Make multiple comparison correction

--- a/tea/build.py
+++ b/tea/build.py
@@ -280,18 +280,17 @@ def create_prediction(prediction_type: str, vars: list, prediction: str):
             lhs_dir = '+'  # Positive relationship/change in variable is the default
             rhs_dir = '+'  # Positive relationship/change in variable is the default
 
-            if lhs.startswith(continuous_negative_relationship):  # "as LHS decreases,..."
+            if lhs.startswith(continuous_negative_relationship) or lhs.startswith(continuous_positive_relationship):  # "as LHS decreases,..."
+                lhs_dir = lhs[0]
                 lhs = lhs[1:]
-                lhs_dir = '-'
                 lhs_var = get_var_from_list(lhs, vars)
             else:
                 # do nothing to lhs, lhs_dir
                 lhs_var = get_var_from_list(lhs, vars)
 
             if rhs.startswith(continuous_negative_relationship) or rhs.startswith(continuous_positive_relationship):
-                relationship = rhs[0]
+                rhs_dir = rhs[0]
                 rhs = rhs[1:]
-                rhs_dir = relationship
                 rhs_var = get_var_from_list(rhs, vars)
             else:
                 # do nothing to rhs, rhs_dir

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,36 +2,36 @@ from tea.ast import NegativeRelationship, PositiveRelationship
 import unittest
 from unittest.mock import Mock
 from tea.build import create_prediction
+from parameterized import parameterized
 
 
 class CreatePredictionTests(unittest.TestCase):
-    def test_positive_continuous_prediction_should_produce_correct_positive_relationship(self):
+
+    @parameterized.expand([
+        [' ~ +', PositiveRelationship],  # Var_1 ~ +Var_2
+        [' ~ ', PositiveRelationship],  # Var_1 ~ Var_2
+        [' ~ +', PositiveRelationship, '+'],  # +Var_1 ~ +Var_2
+        [' ~ ', PositiveRelationship, '+'],  # +Var_1 ~ +Var_2
+
+        [' ~ -', NegativeRelationship],  # Var_1 ~ -Var_2
+        [' ~ ', NegativeRelationship, '-'],  # -Var_1 ~ Var_2
+        [' ~ -', NegativeRelationship, '+'],  # +Var_1 ~ -Var_2
+        [' ~ +', NegativeRelationship, '-'],  # -Var_1 ~ +Var_2
+    ])
+    def test_continuous_prediction_should_produce_correct_relationship(self, relation, expected_relationship_type, first_variable_prefix=''):
         prediction_type = 'continuous prediction'
+        variable_1_name = 'Var_1'
+        variable_2_name = 'Var_2'
+
         var_mock1 = Mock()
-        var_mock1.name = 'Ineq'
+        var_mock1.name = variable_1_name
 
         var_mock2 = Mock()
-        var_mock2.name = 'Prob'
+        var_mock2.name = variable_2_name
 
         vars = [var_mock1, var_mock2]
-        prediction = 'Ineq ~ +Prob'
+        prediction = f'{first_variable_prefix}{variable_1_name}{relation}{variable_2_name}'
         z = create_prediction(prediction_type, vars, prediction)
-        self.assertIsInstance(z, PositiveRelationship)
+        self.assertIsInstance(z, expected_relationship_type)
         self.assertEqual(z.lhs.var, var_mock1)
         self.assertEqual(z.rhs.var, var_mock2)
-
-    def test_negative_continuous_prediction_should_produce_correct_negative_relationship(self):
-        prediction_type = 'continuous prediction'
-        var_mock1 = Mock()
-        var_mock1.name = 'Ineq'
-
-        var_mock2 = Mock()
-        var_mock2.name = 'Prob'
-
-        vars = [var_mock1, var_mock2]
-        prediction = 'Ineq ~ -Prob'
-        z = create_prediction(prediction_type, vars, prediction)
-        self.assertIsInstance(z, NegativeRelationship)
-        self.assertEqual(z.lhs.var, var_mock1)
-        self.assertEqual(z.rhs.var, var_mock2)
-


### PR DESCRIPTION
This PR adds more tests for building as suggested in https://github.com/emjun/tea-lang/pull/46#pullrequestreview-400447517

During this testing I have discover a bug similar to #38 which is now fixed. The bug caused showing `None` in the output for the following: `+Var_1 ~ +Var_2`, `+Var_1 ~ +Var_2`, `+Var_1 ~ -Var_2`. 

**Please review and merge it after #47 as this PR includes a commit from that PR.**