### PR TITLE
Introduce logging class

### DIFF
--- a/tea/api.py
+++ b/tea/api.py
@@ -1,3 +1,4 @@
+from tea.logging.tea_logger import TeaLogger
 from tea.helpers.study_type_determiner import StudyTypeDeterminer
 import pandas as pd
 
@@ -45,6 +46,7 @@ all_results = {}  # Used for multiple comparison correction
 MODE = 'strict'
 
 study_type_determiner = StudyTypeDeterminer()
+
 
 # For testing purposes
 def download_data(url, file_name):
@@ -111,6 +113,8 @@ def define_study_design(design: Dict[str, str]):
 
 
 def assume(user_assumptions: Dict[str, str], mode=None):
+    
+    tea_logger = TeaLogger.get_logger()
     global alpha, alpha_keywords
     global assumptions
     global MODE
@@ -129,14 +133,14 @@ def assume(user_assumptions: Dict[str, str], mode=None):
     # Set MODE for dealing with assumptions
     if mode and mode == 'relaxed':
         MODE = mode
-        log(f"\nRunning under {MODE.upper()} mode.\n")
-        log(
+        tea_logger.log_info(f"\nRunning under {MODE.upper()} mode.\n")
+        tea_logger.log_info(
             f"This means that user assertions will be checked. Should they fail, Tea will issue a warning but proceed as if user's assertions were true.")
     else:
         assert (mode == None or mode == 'strict')
         MODE = 'strict'
-        log(f"\nRunning under {MODE.upper()} mode.\n")
-        log(f"This means that user assertions will be checked. Should they fail, Tea will override user assertions.\n")
+        tea_logger.log_info(f"\nRunning under {MODE.upper()} mode.\n")
+        tea_logger.log_info(f"This means that user assertions will be checked. Should they fail, Tea will override user assertions.\n")
 
 
 def hypothesize(vars: list, prediction: list = None):

--- a/tea/api.py
+++ b/tea/api.py
@@ -166,7 +166,8 @@ def hypothesize(vars: list, prediction: list = None):
     # Interpret AST node, Returns ResultData object <-- this may need to change
     set_mode(MODE)
     num_comparisons = 1
-    vardata_factory = VarDataFactory()
+    study_type_determiner = StudyTypeDeterminer()
+    vardata_factory = VarDataFactory(study_type_determiner)
     result = vardata_factory.create_vardata(dataset_obj, relationship, assumptions, study_design)
 
     # Make multiple comparison correction

--- a/tea/global_vals.py
+++ b/tea/global_vals.py
@@ -45,14 +45,3 @@ assumptions_to_properties = {
 
 # For solver, how to treat user assumptions
 # MODE = 'strict' #can be 'strict' or 'relaxed'
-
-# LOGGING
-# TODO: This shoudl eventually write out to a file somewhere.
-def log(message: str):
-    print(message)
-    # pass
-
-
-def log_debug(message: str):
-    print(message)
-    # pass

--- a/tea/logging/__init__.py
+++ b/tea/logging/__init__.py
@@ -1,0 +1,3 @@
+from tea.logging.logging_target import LoggingTarget
+from tea.logging.tea_logger import TeaLogger
+from tea.logging.tea_logger_configuration import TeaLoggerConfiguration

--- a/tea/logging/logging_target.py
+++ b/tea/logging/logging_target.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class LoggingTarget(Enum):
+    STDOUT = 0
+    FILE = 1

--- a/tea/logging/tea_logger.py
+++ b/tea/logging/tea_logger.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+from tea.logging.tea_logger_configuration import TeaLoggerConfiguration
+from tea.logging.logging_target import LoggingTarget
+
+import logging
+import sys
+
+
+class TeaLogger:
+    __logger_instance: TeaLogger = None
+
+    def __init__(self, logging_level: int, logging_handler: logging.StreamHandler):
+        self.__logger = logging.getLogger('tea_logger')
+        self.__logger.addHandler(logging_handler)
+        self.__logger.setLevel(logging_level)
+
+    @staticmethod
+    def initialize_logger(config: TeaLoggerConfiguration) -> TeaLogger:
+        if config.logging_target == LoggingTarget.FILE:
+            if config.logging_file_target is not None:
+                logging_handler = logging.FileHandler(config.logging_file_target)
+            else:
+                raise AttributeError('When configuring file handler, logging_file_target field is required')
+        else:
+            logging_handler = logging.StreamHandler(sys.stdout)
+        tea_logger = TeaLogger(config.logging_level, logging_handler)
+        TeaLogger.__logger_instance = tea_logger
+        return tea_logger
+
+    @staticmethod
+    def get_logger() -> TeaLogger:
+        if TeaLogger.__logger_instance is None:
+            default_config = TeaLoggerConfiguration()
+            TeaLogger.initialize_logger(default_config)
+            TeaLogger.__logger_instance.log_info('Logger was initialized with default configuration.\nUse TeaLogger.initialize_logger to change it.')
+        return TeaLogger.__logger_instance
+
+    def log_debug(self, message: str):
+        self.__logger.debug(message)
+
+    def log_info(self, message: str):
+        self.__logger.info(message)

--- a/tea/logging/tea_logger_configuration.py
+++ b/tea/logging/tea_logger_configuration.py
@@ -1,0 +1,12 @@
+
+from dataclasses import dataclass
+from tea.logging.logging_target import LoggingTarget
+from typing import Optional
+import logging
+
+
+@dataclass
+class TeaLoggerConfiguration:
+    logging_level: int = logging.INFO
+    logging_target: LoggingTarget = LoggingTarget.STDOUT
+    logging_file_target: Optional[str] = None


### PR DESCRIPTION
**Please review and merge it after #47 as this PR includes a commit from that PR.**

After this PR, we should be able to log all the output to wherever user points. Also, we now have a way to setup whether we want to see debug information or not.

Currently we support two options:
1. Logging to console / file - we can choose between printing to console or writing directoy to a file. If the latter option is set, we need to set `logging_file_target` property.
2. Logging debug / info - we can choose between printing only info and higher messages or debug and higher. 

By default we use *console* and *info* mode. Note that this means that by default user **will not** see messages like 'Currently considering *' or 'Testing assumption' and similar. I think this will improve user experience - they will not have to see a wall of text. 

Example configuration for file.

> from tea.logging import TeaLoggerConfiguration, TeaLogger, LoggingTarget
> import logging
> 
> configuration = TeaLoggerConfiguration()
> configuration.logging_level = logging.INFO
> configuration.logging_file_target = 'test.log'
> configuration.logging_target = LoggingTarget.FILE
> TeaLogger.initialize_logger(configuration)

Example configuration for debugging

> from tea.logging import TeaLoggerConfiguration, TeaLogger
> import logging
> 
> configuration = TeaLoggerConfiguration()
> configuration.logging_level = logging.DEBUG
> TeaLogger.initialize_logger(configuration)

If user is happy with console output and seeing only info messages, he/she does not have to do anything. 

I wanted to add this to some documentation but I am unsure where to put it. 