### PR TITLE
remove obsolete word "TODO", keep the rest as good documenation

### DIFF
--- a/tea/helpers/evaluateHelperMethods.py
+++ b/tea/helpers/evaluateHelperMethods.py
@@ -851,7 +851,7 @@ def spearman_corr(dataset: Dataset, predictions, combined_data: CombinedData):
 
     data = []
     for var in combined_data.vars:
-        # TODO: Check that var is ordinal. If so, then assign all ordinal values numbers 
+        # Check that var is ordinal. If so, then assign all ordinal values numbers 
         # Compare to without converting to numbers (in Evernote)
         var_data = get_data(dataset, var)
         if var.is_ordinal():


### PR DESCRIPTION
##### SUMMARY
update TODO comment: remove the obsolete word "TODO", keep the rest of the comment as good documentation. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tea/helpers/evaluateHelperMethods.py (line:854)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not updated accordingly at the moment. Please check the following commit: 
https://github.com/tea-lang-org/tea-lang/commit/b692e2b24143cb588f51f30bfbac90d272e0ad77